### PR TITLE
[Feature] Added linting. Separated identity interface from implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
             - node_modules
 
       # run tests!
-      #- run:
-      #    name: Solidity Linter
-      #    command: npm run lint:sol
+      - run:
+          name: Solidity Linter
+          command: npm run lint:sol
 
       - run:
           name: Javascript Linter

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -19,7 +19,7 @@ contract Identity is ERC725b, Ownable, Destructible {
 
     /**
      * @dev Identity Constructor. Assigns a Management key to the creator.
-     * @param _sender — The creator of this identity.
+     * @param sender — The creator of this identity.
      */
     function Identity(address sender) public {
         // Adds sender as a management key

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.19;
 
+import './lib/ERC725b.sol';
+
 import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
 import 'zeppelin-solidity/contracts/lifecycle/Destructible.sol';
 
@@ -7,39 +9,29 @@ import 'zeppelin-solidity/contracts/lifecycle/Destructible.sol';
  * @title Identity
  * @dev Contract that represents an identity
  */
-contract Identity is Ownable, Destructible {
+contract Identity is ERC725b, Ownable, Destructible {
     bytes16 idVersion = "0.0.1";
-
-    // TODO: Add constants for key schemes
-
-    // TODO: move to an interface
-    uint256 constant MANAGEMENT_KEY = 1;
-    uint256 constant ACTION_KEY = 2;
-    uint256 constant CLAIM_SIGNER_KEY = 3;
-    uint256 constant ENCRYPTION_KEY = 4;
-
-    struct Key {
-        address key;    //ERC725 defines it as bytes32
-        uint256 keyType;
-        uint256 scheme;
-    }
-
-    // maps from type to keys
-    mapping(bytes32 => Key) keys;
-
-    event KeyAdded(address indexed key, uint256 indexed keyType);
-    event KeyRemoved(address indexed key, uint256 indexed keyType);
 
     modifier onlyManager () {
         require(keys[keccak256(msg.sender, MANAGEMENT_KEY)].key != 0);
         _;
     }
 
+    /**
+     * @dev Identity Constructor. Assigns a Management key to the creator.
+     * @param _sender — The creator of this identity.
+     */
     function Identity(address sender) public {
         // Adds sender as a management key
-        keys[keccak256(sender, MANAGEMENT_KEY)] = Key(sender, MANAGEMENT_KEY, 1);   // TODO: set proper scheme argument
+        keys[keccak256(sender, MANAGEMENT_KEY)] = Key(sender, MANAGEMENT_KEY, ECDSA);
     }
 
+    /**
+     * @dev Adds a new key (address) to the identity
+     * @param _key — The key (address) to be added
+     * @param _type — The key type (Management, Action, etc)
+     * @param _scheme — The scheme to be used for verifying this key (ECDSA, RSA, etc)
+     */
     function addKey(address _key, uint256 _type, uint256 _scheme)
         onlyManager
         public
@@ -51,6 +43,11 @@ contract Identity is Ownable, Destructible {
         return true;
     }
 
+    /**
+     * @dev Retrieves a key by its address and type
+     * @param _key — The key (address) to be retrieved
+     * @param _type — The key type (Management, Action, etc)
+     */
     function getKey(address _key, uint256 _type)
         public
         view
@@ -62,6 +59,11 @@ contract Identity is Ownable, Destructible {
         return (keys[index].key, keys[index].keyType, keys[index].scheme);
     }
 
+    /**
+     * @dev Removes a key (doable only by addresses added of the MANAGEMENT type)
+     * @param _key — The key (address) to be removed
+     * @param _type — The key type (Management, Action, etc)
+     */
     function removeKey(address _key, uint256 _type)
         onlyManager
         public
@@ -69,7 +71,7 @@ contract Identity is Ownable, Destructible {
     {
         bytes32 index = keccak256(_key, _type);
         delete keys[index];
-        
+
         KeyRemoved(_key, _type);
 
         return true;

--- a/contracts/lib/ERC725b.sol
+++ b/contracts/lib/ERC725b.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.4.19;
+
+
+/**
+ * @title ERC725b
+ * @dev Identity interface _based_ on the ERC725 proposal
+ */
+contract ERC725b {
+    // Constants for key types (purposes)
+    uint256 public constant MANAGEMENT_KEY = 1;
+    uint256 public constant ACTION_KEY = 2;
+    uint256 public constant CLAIM_SIGNER_KEY = 3;
+    uint256 public constant ENCRYPTION_KEY = 4;
+
+    // Constants for key schemes
+    uint256 public constant ETH_ADDR = 1;
+    uint256 public constant RSA = 2;
+    uint256 public constant ECDSA = 3;
+
+    struct Key {
+        address key;    //ERC725 defines it as bytes32
+        uint256 keyType;
+        uint256 scheme;
+    }
+
+    mapping(bytes32 => Key) public keys;
+
+    event KeyAdded(address indexed key, uint256 indexed keyType);
+    event KeyRemoved(address indexed key, uint256 indexed keyType);
+    //event KeyReplaced(address indexed oldKey, address indexed newKey, uint256 indexed keyType);
+    //event ExecutionRequested(bytes32 indexed executionId, address indexed to, uint256 indexed value, bytes data);
+    //event Executed(bytes32 indexed executionId, address indexed to, uint256 indexed value, bytes data);
+    //event Approved(bytes32 indexed executionId, bool approved);
+
+    function getKey(address _key, uint256 _type) public view returns (address, uint256, uint256);
+    function addKey(address _key, uint256 _type, uint256 _scheme) public returns (bool);
+    function removeKey(address _key, uint256 _type) public returns (bool);
+    //function replaceKey(address _oldKey, address _newKey) public returns (bool success);
+    //function execute(address _to, uint256 _value, bytes _data) public returns (bytes32 executionId);
+    //function approve(bytes32 _id, bool _approve) public returns (bool success);
+}


### PR DESCRIPTION
Added linting and comments that comply with linting check. Also, splitted identity contract interface from implementation, using ERC725b as the interface.

It's called ERC725b and not ERC725 because it still differs from "official" ERC725 interface.