### PR TITLE
[Feature] Added permissioning checks to service methods

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,4 @@
 module.exports = {
-  skipFiles: []
+  //skipFiles: []
+  copyNodeModules: true
 }

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -85,6 +85,7 @@ contract Identity is ERC725b, ServiceCollection, Ownable, Destructible {
      */
     function addService(bytes32 _type, string _endpoint)
         public
+        onlyManager
         returns (bool)
     {
         bytes memory serviceBytes = bytes(servicesByType[_type]);
@@ -119,7 +120,11 @@ contract Identity is ERC725b, ServiceCollection, Ownable, Destructible {
      * @dev Removes a service endpoint of the given type
      * @param _type — The service type (short string) E.g. "HubService"
      */
-    function removeService(bytes32 _type) public returns (bool) {
+    function removeService(bytes32 _type)
+        public
+        onlyManager
+        returns (bool)
+    {
         bytes memory serviceBytes = bytes(servicesByType[_type]);
         require(serviceBytes.length > 0);
 
@@ -131,18 +136,4 @@ contract Identity is ERC725b, ServiceCollection, Ownable, Destructible {
 
         return true;
     }
-
-    /*function getServices()
-        public
-        view
-        returns (bytes32[])     // does this work?
-    {
-        bytes32[] memory response;
-        for (uint256 i = 0; i < servicesCount; i++) {
-            response[i] = services[i];
-            //response.length = response.length + 1;
-        }
-
-        return response;
-    }*/
 }

--- a/test/identity_test.js
+++ b/test/identity_test.js
@@ -84,6 +84,15 @@ contract('Identity', accounts => {
       assert.equal(servicesCount, 2)
     })
 
+    it('fails to add services from a non manager address', async () => {
+      const serviceEndpoint =
+        'https://xdi.example.com/.identity/did:key:01234567abcdef/'
+      const serviceType = 'XDIService'
+      await assertThrows(
+        identity.addService(serviceType, serviceEndpoint, { from: user2 })
+      )
+    })
+
     it('updates existing service endpoint', async () => {
       const serviceEndpoint =
         'https://hub.example.com/.identity/did:key:9876432cdefajj/'
@@ -97,10 +106,28 @@ contract('Identity', accounts => {
       assert.equal(servicesCount, 2)
     })
 
+    it('fails to update services from a non manager address', async () => {
+      const serviceEndpoint =
+        'https://hub.attacker.com/.identity/did:key:01234567abcdef/'
+      const serviceType = 'HubService'
+      await assertThrows(
+        identity.addService(serviceType, serviceEndpoint, { from: user2 })
+      )
+    })
+
     it('removes existing service endpoint', async () => {
       const serviceType = 'HubService'
       await identity.removeService(serviceType)
       await assertThrows(identity.getServiceByType(serviceType))
+
+      // check the services count is correct
+      const servicesCount = Number(await identity.servicesCount.call())
+      assert.equal(servicesCount, 1)
+    })
+
+    it('fails to remove existing service endpoint if caller is not a manager', async () => {
+      const serviceType = 'MessagingService'
+      await assertThrows(identity.removeService(serviceType, { from: user2 }))
 
       // check the services count is correct
       const servicesCount = Number(await identity.servicesCount.call())


### PR DESCRIPTION
Added onlyManager modifier (along with all due unit tests) to ensure only addresses with management keys can perform such edits to the contract.